### PR TITLE
Extraction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Options:
   -V, --version          output the version number
   -p, --prerelease       download prerelease
   -s, --search <regexp>  filter assets name
+  -z, --zipped           don't extract zip files
 ```
 
 ### Example
@@ -62,6 +63,7 @@ var downloadRelease = require('download-github-release');
 var user = 'some user';
 var repo = 'some repo';
 var outputdir = 'some output directory';
+var leaveZipped = false;
 
 // Define a function to filter releases.
 function filterRelease(release) {
@@ -75,7 +77,7 @@ function filterAsset(asset) {
   return asset.name.indexOf('windows') >= 0;
 }
 
-downloadRelease(user, repo, outputdir, filterRelease, filterAsset)
+downloadRelease(user, repo, outputdir, filterRelease, filterAsset, leaveZipped)
   .then(function() {
     console.log('All done!');
   })
@@ -87,7 +89,6 @@ downloadRelease(user, repo, outputdir, filterRelease, filterAsset)
 ## TODO
 
 - other compression formats
-- option to disable unzipping
 - option to download specific release instead of latest?
 - option to download source?
 - private repos?

--- a/src/cli.js
+++ b/src/cli.js
@@ -12,6 +12,7 @@ commander
   .arguments('<user> <repo> [outputdir]')
   .option('-p, --prerelease', 'download prerelease')
   .option('-s, --search <regexp>', 'filter assets name')
+  .option('-z, --zipped', 'don\'t extract zip files')
   .parse(process.argv);
 
 const user = commander.args[0];
@@ -34,5 +35,5 @@ function filterAsset(asset) {
   return new RegExp(commander.search).exec(asset.name);
 }
 
-downloadRelease(user, repo, outputdir, filterRelease, filterAsset)
+downloadRelease(user, repo, outputdir, filterRelease, filterAsset, !!commander.zipped)
   .catch(err => console.error(err.message));

--- a/src/downloadRelease.js
+++ b/src/downloadRelease.js
@@ -12,7 +12,7 @@ function pass() {
   return true;
 }
 
-function downloadRelease(user, repo, outputdir, filterRelease = pass, filterAsset = pass) {
+function downloadRelease(user, repo, outputdir, filterRelease = pass, filterAsset = pass, leaveZipped = false) {
   const bars = new MultiProgress(process.stdout);
 
   return getReleases(user, repo)
@@ -41,7 +41,7 @@ function downloadRelease(user, repo, outputdir, filterRelease = pass, filterAsse
 
         return download(asset.browser_download_url, dest, progress)
           .then(() => {
-            if (/\.zip$/.exec(destf)) {
+            if (!leaveZipped && /\.zip$/.exec(destf)) {
               return extract(destf, outputdir).then(() => fs.unlinkSync(destf));
             }
 

--- a/test/downloadRelease.js
+++ b/test/downloadRelease.js
@@ -3,7 +3,7 @@ import path from 'path';
 import nock from 'nock';
 import tmp from 'tmp';
 import downloadRelease from '../src/downloadRelease';
-import nockServer, { fileTxt } from './utils/nockServer';
+import nockServer, { fileTxt, fileZip } from './utils/nockServer';
 
 describe('#downloadRelease()', () => {
   let tmpobj;
@@ -22,6 +22,29 @@ describe('#downloadRelease()', () => {
       .then(() => {
         fs.readFileSync(path.join(tmpobj.name, '/file/file.txt'), 'utf8')
           .should.be.exactly(fileTxt);
+        fs.readFileSync(path.join(tmpobj.name, '/file-darwin-amd64.txt'), 'utf8')
+          .should.be.exactly(fileTxt);
+      })
+  );
+});
+
+describe('#downloadRelease()', () => {
+  let tmpobj;
+
+  before(() => {
+    nockServer();
+    tmpobj = tmp.dirSync({ unsafeCleanup: true });
+  });
+  after(() => {
+    nock.cleanAll();
+    tmpobj.removeCallback();
+  });
+  
+  it('downloads a release (without unzipping it)', () =>
+    downloadRelease('me', 'test', tmpobj.name, undefined, a => a.name.indexOf('darwin-amd64') >= 0, true)
+      .then(() => {
+        fs.readFileSync(path.join(tmpobj.name, '/file-darwin-amd64.zip')).toString('hex')
+          .should.be.exactly(fileZip.toString('hex'));
         fs.readFileSync(path.join(tmpobj.name, '/file-darwin-amd64.txt'), 'utf8')
           .should.be.exactly(fileTxt);
       })


### PR DESCRIPTION
This is what I did to make extraction optional. It adds a command line argument `-z, --zipped` to the CLI that means "leave them zipped". The JavaScript API also has a new last argument that is optional and defaults to false called `leaveZipped`.

Let me know if that's cool and if so I'll add a to test/downloadRelease.js

fixes #2